### PR TITLE
#181151230 Configure Authors Haven to use PostgreSQL as DB Engine

### DIFF
--- a/authors/settings.py
+++ b/authors/settings.py
@@ -11,15 +11,16 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
+from dotenv import load_dotenv
 
+load_dotenv()
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '5ne9v2=-r7a=k(&nt0(!l78nld5!ik&tdttn4i-6^-cw-!a%+('
+SECRET_KEY = os.environ.get('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -100,9 +101,15 @@ WSGI_APPLICATION = 'authors.wsgi.application'
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
 DATABASES = {
+
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME" : os.environ.get('NAME'),
+        "USER" : os.environ.get('USER'),
+        "PASSWORD" : os.environ.get('PASSWORD'),
+        "HOST" : os.environ.get('HOST'),
+        "PORT" : os.environ.get('PORT')
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ PyJWT==2.3.0
 pytz==2021.3
 six==1.16.0
 tzdata==2021.5
+psycopg2==2.9.3
+python-dotenv==0.19.2


### PR DESCRIPTION
####  What does this PR do?
- Configures Authors Haven to use PostgreSQL as DB Engine

####  Description of Task to be completed?
- Create PostgreSQL database
- Configure Authors Haven to use PostgreSQL as DB Engine

####  How should this be manually tested?
- A database with a database name is created; In this case, the database name used is "**Invictus**".
- By running **"psql -U postgres"**, provide a password if required, run "**postgres=# \c invictus;**", (invictus is the name of the database). In order to see the tables that have been created, run **"invictus=# \dt;"**.
 
####  Any background context you want to provide?
- No

####  What are the relevant pivotal tracker stories?
- https://www.pivotaltracker.com/story/show/181151230

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/69035525/154684254-38450944-cab8-48a4-981e-21f691c7201f.png)

![image](https://user-images.githubusercontent.com/69035525/154673878-76dc170b-4278-4339-92c3-aafce8e5e07c.png)

####  Questions:
- None

[Start #181151230]
