### PR TITLE
 #181151224 add coveralls code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,18 @@ jobs:
              pip install -r requirements.txt
              python manage.py makemigrations
              python manage.py migrate
-             python manage.py test
+             coverage run manage.py test
+             coverage report
+             coverage html
+             coveralls
+      - store_artifacts:
+          path: htmlcov
 
 workflows:
   sample: 
     jobs:
       - build-and-test
+
+notify:
+  webhooks:
+    - url: https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,21 @@
+[run]
+source = .
+branch = False
+timid = True
+[report]
+show_missing = True
+include = *.py
+omit =
+    tests.py
+    *_test.py
+    *_tests.py
+    */site-packages/*
+    */migrations/*
+    authors/settings.py
+    authors/tests.py
+    authors/wsgi.py
+    authors/asgi.py
+    manage.py
+[html]
+title = Code Coverage
+directory = local_coverage_report

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: $repo_token

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # writers-space-invictus-backend - A Social platform for the creative at heart
 
-[![CircleCI](https://circleci.com/gh/Emmanuel-Dominic/writers-space-invictus-backend/tree/develop.svg?style=svg)](https://circleci.com/gh/Emmanuel-Dominic/writers-space-invictus-backend/tree/develop)
+[![CircleCI](https://circleci.com/gh/Emmanuel-Dominic/writers-space-invictus-backend/tree/develop.svg?style=svg)](https://circleci.com/gh/Emmanuel-Dominic/writers-space-invictus-backend/tree/develop) [![Coverage Status](https://coveralls.io/repos/github/Emmanuel-Dominic/writers-space-invictus-backend/badge.svg?branch=ch-add-coveralls-code-coverage-181151224)](https://coveralls.io/github/Emmanuel-Dominic/writers-space-invictus-backend?branch=ch-add-coveralls-code-coverage-181151224)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/5cde24fd52344960ad0b7d951ca8ccb1)](https://www.codacy.com/gh/Emmanuel-Dominic/writers-space-invictus-backend/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Emmanuel-Dominic/writers-space-invictus-backend&amp;utm_campaign=Badge_Grade)
 
 This is a project system that enables authors to write articles that are to reach a massive audience. In the case of article writing, different authors can comment, share, bookmark, like and follow the publisher of the article.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ tzdata==2021.5
 psycopg2==2.9.3
 python-dotenv==0.19.2
 drf-yasg==1.20.0
+coveralls==3.3.1


### PR DESCRIPTION
### What does this PR do?
 - This PR  adds coveralls code coverage
 
### Description of Task to be completed?
 - This task enables display of test coverage stats on the Coveralls status badge

### How should this be manually tested?
 -  By checking the readme file of this branch https://github.com/Emmanuel-Dominic/writers-space-invictus-backend/tree/ch-add-coveralls-code-coverage-181151224
 
### Any background context you want to provide?
 -  Run the following commands to test for code coverage:
 coverage run manage.py test
 coverage report
 coverage html
 
### What are the relevant pivotal tracker stories?
 - https://www.pivotaltracker.com/story/show/181151224
 
### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/69036637/157849303-9f9be8c9-8082-4b4f-997b-0dc47e399451.png)

### Questions:
 - None
 
[start #181151224]